### PR TITLE
Update README.md concerning AndroidManifest.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ And add this to ```onRequestPermissionsResult```
 ```java
 mRequestObject.onRequestPermissionsResult(requestCode, permissions, grantResults);
 ```
+Add the requested permission to your ```AndroidManifest.xml``` as well
+```xml
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+```
 
 ###Dependency?
 ```groovy


### PR DESCRIPTION
Add 2 lines in the README.md to inform the user about the AndroidManifest.xml. The permission requested has to be added to the manifest for the library to work correctly and for the permission to be requested.