### PR TITLE
Create PermissionRequestObject with Fragment sends Activity.

### DIFF
--- a/PermissionUtils/src/main/java/com/github/kayvannj/permission_utils/PermissionUtil.java
+++ b/PermissionUtils/src/main/java/com/github/kayvannj/permission_utils/PermissionUtil.java
@@ -67,7 +67,11 @@ public class PermissionUtil {
         }
 
         public PermissionRequestObject request(String... permissionNames) {
-            return new PermissionRequestObject(mActivity, permissionNames);
+            if (mActivity != null) {
+                return new PermissionRequestObject(mActivity, permissionNames);
+            } else {
+                return new PermissionRequestObject(mFragment, permissionNames);
+            }
         }
     }
 


### PR DESCRIPTION
I noticed my app crashing saying that mFragment was null when I used `public PermissionUtil.PermissionRequestObject request(String... permissionNames)`. Found out why! 